### PR TITLE
Only flag regexp calls that use values known at compile time

### DIFF
--- a/regexponce.go
+++ b/regexponce.go
@@ -1,6 +1,8 @@
 package regexponce
 
 import (
+	"go/ast"
+	"go/token"
 	"go/types"
 	"strings"
 
@@ -8,6 +10,7 @@ import (
 	"github.com/gostaticanalysis/comment/passes/commentmap"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/buildssa"
+	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/ssa"
 )
 
@@ -17,7 +20,7 @@ const doc = `Below functions should be called at once for performance.
 - regexp.CompilePOSIX
 - regexp.MustCompilePOSIX
 
-Allow call in init, and main(except for in for loop) functions because each function is called only once.
+Allow call in init and main functions (unless call is in a for loop) because these functions are only called once.
 `
 
 // Analyzer is check correct call of regexp package.
@@ -29,6 +32,30 @@ var Analyzer = &analysis.Analyzer{
 		buildssa.Analyzer,
 		commentmap.Analyzer,
 	},
+}
+
+var _ ast.Visitor = &funcCallVisitor{}
+
+// funcCallVisitor is an ast.Visitor that sets usesVarOrCall to true
+// if it visits a node that is a variable or a call expression.
+type funcCallVisitor struct {
+	usesVarOrCall bool
+}
+
+func (v *funcCallVisitor) Visit(node ast.Node) (w ast.Visitor) {
+	switch typ := node.(type) {
+	case *ast.Ident:
+		if typ.Obj.Kind == ast.Var {
+			v.usesVarOrCall = true
+		}
+	case *ast.CallExpr:
+		v.usesVarOrCall = true
+	}
+	// once this is true, no need to visit any more nodes
+	if v.usesVarOrCall {
+		return nil
+	}
+	return v
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -61,16 +88,51 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 			for _, instr := range b.Instrs {
 				for _, f := range fs {
-					if analysisutil.Called(instr, nil, f) {
-						pass.Reportf(instr.Pos(), "%s must be called only once at initialize", f.FullName())
-						break
+					if !analysisutil.Called(instr, nil, f) {
+						continue
 					}
+
+					// if call parameters contain a variable or function call, do not flag
+					instrTokenPos := instr.Pos()
+					// get ast.Node for current position
+					if gotPath, _ := astutil.PathEnclosingInterval(fileForPos(pass.Files, instrTokenPos), instrTokenPos, instrTokenPos); len(gotPath) > 0 {
+						// if node is a function call and parameter contains variable or function call result, do not flag
+						if callExpr, ok := gotPath[0].(*ast.CallExpr); ok && variablesOrCallInCallExpr(callExpr) {
+							continue
+						}
+					}
+
+					pass.Reportf(instrTokenPos, "%s must be called only once at initialize", f.FullName())
 				}
 			}
 		}
 	}
 
 	return nil, nil
+}
+
+// variablesOrCallInCallExpr returns true if the provided *ast.CallExpr has
+// at least one argument and if the first argument contains a reference to a
+// variable or a function call.
+func variablesOrCallInCallExpr(callExpr *ast.CallExpr) bool {
+	if len(callExpr.Args) == 0 {
+		return false
+	}
+	visitor := &funcCallVisitor{}
+	ast.Walk(visitor, callExpr.Args[0])
+	return visitor.usesVarOrCall
+}
+
+// fileForPos returns the *ast.File in the provided set of files that contains
+// the provided token.Pos. Returns nil if the provided position does not occur
+// in the provided files.
+func fileForPos(files []*ast.File, pos token.Pos) *ast.File {
+	for _, file := range files {
+		if pos >= file.Pos() && pos <= file.End() {
+			return file
+		}
+	}
+	return nil
 }
 
 func inFor(b *ssa.BasicBlock) bool {

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -27,6 +27,21 @@ func f() {
 	hoge(`^[a-z]+\[[0-9]+\]$`) // want `regexp.MustCompile must be called only once at initialize`
 }
 
+func doNotWarnWithVariable(input string) {
+	regexp.MustCompile(input) // OK because function parameter is a variable
+
+	returnWord := func(input string) string {
+		return input
+	}
+	regexp.MustCompile(returnWord(input)) // OK because function parameter is a function call
+
+	const constVal = ".*"
+	regexp.MustCompile(input + constVal) // OK because function parameter contains a variable
+
+	regexp.MustCompile(constVal)            // want `regexp.MustCompile must be called only once at initialize`
+	regexp.MustCompile(constVal + constVal) // want `regexp.MustCompile must be called only once at initialize`
+}
+
 func main() {
 	var validID = regexp.MustCompile(`^[a-z]+\[[0-9]+\]$`) // OK because main function runs only once.
 	fmt.Println(validID.MatchString("adam[23]"))


### PR DESCRIPTION
Do not flag function calls that have variables or function calls
in their arguments, as such code cannot be refactored to only be
called once.